### PR TITLE
[feat] Account for non-Intel Macs

### DIFF
--- a/src/providers/JavaDownload.ts
+++ b/src/providers/JavaDownload.ts
@@ -33,13 +33,25 @@ export async function getJre(ref: Ref): Promise<string> {
   const platform: NodeJS.Platform = await ipcRenderer.invoke('getPlatform');
   // const platform: NodeJS.Platform = 'linux';
 
+  const getMacArch = () => {
+    const arch = os.arch();
+
+    if (arch === 'x64') {
+      return 'x64';
+    } else if (arch === 'arm64') {
+      return 'aarch64';
+    }
+
+    return arch;
+  };
+
   const flags = {
     // https://api.adoptium.net/q/swagger-ui/#/Binary/getBinary
     // /v3/binary/latest/{feature_version}/{release_type}/{os}/{arch}/{image_type}/{jvm_impl}/{heap_size}/{vendor}
     feature_version: '17', // Drehmal is 1.17+, so use JRE 17
     release_type: 'ga',
     os: osMap[platform],
-    arch: os.arch(),
+    arch: platform === 'darwin' ? getMacArch() : os.arch(),
     image_type: 'jre',
     jvm_impl: 'hotspot',
     heap_size: 'normal',


### PR DESCRIPTION
Fixes the issue where non-Intel Mac users get stuck on "Extracting Java runtime" due to the wrong arch type resulting in a 404 download URL.